### PR TITLE
CCDIMTP-602: Update EM source

### DIFF
--- a/apps/platform/src/sections/evidence/EpigeneticModification/Description.jsx
+++ b/apps/platform/src/sections/evidence/EpigeneticModification/Description.jsx
@@ -9,28 +9,6 @@ const Description = ({ symbol, name }) => (
     <Link to={mtpLinks.openPedCan} external>
       OpenPedCan
     </Link>
-    {', '}
-    <Link
-      to=" https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000218.v23.p8"
-      external
-    >
-      TARGET (v23)
-    </Link>
-    {', '}
-    <Link
-      to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001436.v1.p1"
-      external
-    >
-      Kids First Neuroblastoma
-    </Link>
-    {', '}
-    <Link to="https://alexslemonade.github.io/OpenPBTA-manuscript/" external>
-      OpenPBTA for CBTN and PNOC (v21)
-    </Link>
-    {', '}
-    <Link to="https://www.oncokb.org/news#07162021" external>
-      OncoKB (v3.5)
-    </Link>
   </>
 );
 

--- a/apps/platform/src/sections/target/EpigeneticModification/Description.jsx
+++ b/apps/platform/src/sections/target/EpigeneticModification/Description.jsx
@@ -9,28 +9,6 @@ const Description = ({ symbol }) => (
     <Link to={mtpLinks.openPedCan} external>
       OpenPedCan
     </Link>
-    {', '}
-    <Link
-      to=" https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000218.v23.p8"
-      external
-    >
-      TARGET (v23)
-    </Link>
-    {', '}
-    <Link
-      to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001436.v1.p1"
-      external
-    >
-      Kids First Neuroblastoma
-    </Link>
-    {', '}
-    <Link to="https://alexslemonade.github.io/OpenPBTA-manuscript/" external>
-      OpenPBTA for CBTN and PNOC (v21)
-    </Link>
-    {', '}
-    <Link to="https://www.oncokb.org/news#07162021" external>
-      OncoKB (v3.5)
-    </Link>
   </>
 );
 


### PR DESCRIPTION
Under Target and Evidence page:
- Update the source of Epigenetic Modification(EM) widget to only include [OpenPedCan](https://github.com/PediatricOpenTargets/documentation) 