### PR TITLE
CCDIMTP-609: Change SA and GX

### DIFF
--- a/apps/platform/public/profiles/default.js
+++ b/apps/platform/public/profiles/default.js
@@ -42,7 +42,7 @@ var configProfile = {
   partnerEvidenceSectionIds: ['encore', 'otCrispr', 'validationlab'],
 
   // datatypes
-  hideDataTypes: [''],
+  hideDataTypes: ['pediatric_cancer'],
   partnerDataTypes: ['ot_partner', 'ot_validation_lab'],
 
   // for datasources we only set those that are private (partner)

--- a/apps/platform/src/sections/common/OpenPedCanGeneExpression/Body.jsx
+++ b/apps/platform/src/sections/common/OpenPedCanGeneExpression/Body.jsx
@@ -144,7 +144,7 @@ function Body({
   return (
     <SectionItem
       definition={definition}
-      chipText={entity === 'evidence' ? dataTypesMap.rna_expression : ''}
+      chipText={entity === 'evidence' ? dataTypesMap.pediatric_cancer : ''}
       request={{ data: { linearPlot, log10Plot, json }, error, loading }}
       renderDescription={() => (
         <Description symbol={label.symbol} name={label.name} />

--- a/apps/platform/src/sections/common/OpenPedCanSomaticAlterations/Body.jsx
+++ b/apps/platform/src/sections/common/OpenPedCanSomaticAlterations/Body.jsx
@@ -85,7 +85,7 @@ function Body({
   return (
     <SectionItem
       definition={definition}
-      chipText={entity === 'evidence' ? dataTypesMap.somatic_mutation : ''}
+      chipText={entity === 'evidence' ? dataTypesMap.pediatric_cancer : ''}
       request={request}
       renderDescription={() => (
         <Description symbol={label.symbol} name={label.name} />

--- a/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Summary.jsx
+++ b/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Summary.jsx
@@ -75,7 +75,7 @@ function Summary({
         const hasData = definition.hasData(data);
         return hasData ? 'Available' : 'no data';
       }}
-      subText={dataTypesMap.rna_expression}
+      subText={dataTypesMap.pediatric_cancer}
     />
   );
 }

--- a/apps/platform/src/sections/evidence/OpenPedCanSomaticAlterations/Summary.jsx
+++ b/apps/platform/src/sections/evidence/OpenPedCanSomaticAlterations/Summary.jsx
@@ -17,7 +17,7 @@ function Summary({ definition }) {
         const hasData = definition.hasData(data);
         return hasData ? 'Available' : 'no data';
       }}
-      subText={dataTypesMap.somatic_mutation}
+      subText={dataTypesMap.pediatric_cancer}
     />
   );
 }


### PR DESCRIPTION
- Update Data Type of OpenPedCan Gene Expression(GX) widget from `rna_expression` to `pediatric_cancer`
- Update Data Type of OpenPedCan Somatic Alterations(SA) widget from `somatic_mutation` to `pediatric_cancer`
- Hidden the pediatric_cancer datatype from displaying in the facets and heatmap of the associations pages. 