### PR TITLE
[CCDIMTP-524]: Add TCGA data/plot under GX widget

### DIFF
--- a/apps/platform/src/config.js
+++ b/apps/platform/src/config.js
@@ -14,7 +14,7 @@ const config = {
   geneticsPortalUrl:
     window.injectedEnv.configGeneticsPortalUrl ?? 'https://genetics.opentargets.org',
 
-  chopRServer: window.injectedEnv.chopRServer ?? 'https://openpedcan-api.d3b.io',
+  chopRServer: window.injectedEnv.chopRServer ?? 'https://openpedcan-api-qa.d3b.io',
   frontendVersion: window.injectedEnv.frontend_version ?? '1.0.0',
   backendVersion: window.injectedEnv.backend_version ?? '1.0.0',
   mtpConfig: 'https://raw.githubusercontent.com/CBIIT/mtp-config/'+configVersion,

--- a/apps/platform/src/sections/common/OpenPedCanGeneExpression/Image.jsx
+++ b/apps/platform/src/sections/common/OpenPedCanGeneExpression/Image.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+function DisplayPlot({ imageSrc, imageAlt, classes }){
+  if (imageSrc === '') return null;
+  
+  return (
+    <img
+      src={`data:image/png;base64,${imageSrc}`}
+      className={classes}
+      alt={imageAlt}
+    />
+  );
+};
+
+export default DisplayPlot;

--- a/apps/platform/src/sections/common/OpenPedCanGeneExpression/PlotContainer.jsx
+++ b/apps/platform/src/sections/common/OpenPedCanGeneExpression/PlotContainer.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Grid } from '@material-ui/core';
+import DataDownloader from '../../../components/Table/DataDownloader';
+
+const PlotContainer = ({ 
+  children,
+  DDRows,
+  DDColumns,
+  DDFileStem,
+  captionLabel = "Download data as",
+  id="",
+}) => (
+  <Grid container>
+    <DataDownloader
+      rows={DDRows}
+      columns={DDColumns}
+      fileStem={DDFileStem}
+      captionLabel={captionLabel}
+    />
+    <Grid item xs={12} style={{ overflow: 'auto' }} id={id}>
+      {children}
+    </Grid>
+  </Grid>
+);
+
+export default PlotContainer;

--- a/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Body.jsx
+++ b/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Body.jsx
@@ -10,7 +10,7 @@ function Body({ definition, id, label }) {
   const { ensgId: ensemblId, efoId } = id;
   const downloadFileName = `OpenPedCanGeneExpression-${ensemblId}-${efoId}`;
   const imageAlt = 'Single-gene single-disease all-GTEx-tissue-subgroups';
-  const configAPI = `${config.mtpConfig}/front-end/page_evidence/GeneExpressionGTEx_Config.json`;
+  const configAPI = `${config.mtpConfig}/front-end/page_evidence`;
   return (
     <OpenPedCanGeneExpressionBody
       definition={definition}

--- a/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Body.jsx
+++ b/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Body.jsx
@@ -1,28 +1,34 @@
 import React from 'react';
-import { getGeneDiseaseGtexPlot } from '../../../utils/externalAPI';
+import { getGeneDiseaseGtexPlot, getGeneDiseaseTcgaPlot } from '../../../utils/externalAPI';
 import config from '../../../config';
 import Description from './Description';
 
-import { getData } from './Summary';
+import { getGtexData, getTcgaData } from './Summary';
 import { Body as OpenPedCanGeneExpressionBody } from '../../common/OpenPedCanGeneExpression';
 
 function Body({ definition, id, label }) {
+
   const { ensgId: ensemblId, efoId } = id;
   const downloadFileName = `OpenPedCanGeneExpression-${ensemblId}-${efoId}`;
-  const imageAlt = 'Single-gene single-disease all-GTEx-tissue-subgroups';
+  const gtexImageAlt = 'Single-gene single-disease all-GTEx-tissue-subgroups';
+  const tcgaImageAlt = 'Single-gene all-diseases all-TCGA';
   const configAPI = `${config.mtpConfig}/front-end/page_evidence`;
+
   return (
     <OpenPedCanGeneExpressionBody
       definition={definition}
       id={id}
-      getData={getData}
-      getPlot={getGeneDiseaseGtexPlot}
       label={label}
       entity="evidence"
       Description={Description}
-      fileStem={downloadFileName}
-      imageAlt={imageAlt}
       configAPI={configAPI}
+      fileStem={downloadFileName}
+      getGtexData={getGtexData}
+      getGtexPlot={getGeneDiseaseGtexPlot}
+      gtexImageAlt={gtexImageAlt}
+      getTcgaData={getTcgaData}
+      getTcgaPlot={getGeneDiseaseTcgaPlot}
+      tcgaImageAlt={tcgaImageAlt}
     />
   );
 }

--- a/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Summary.jsx
+++ b/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/Summary.jsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import SummaryItem from '../../../components/Summary/SummaryItem';
 
-import { getGeneDiseaseGtexJSON } from '../../../utils/externalAPI';
+import { getGeneDiseaseGtexJson, getGeneDiseaseTcgaJson } from '../../../utils/externalAPI';
 import { dataTypesMap } from '../../../dataTypes';
 import { setDisplaySettingForExternal } from '../../common/OpenPedCanGeneExpression/utils';
 
-export async function getData(id, setData, setLoading, setHasData = _ => _) {
+export async function getTcgaData(id, setData, setLoading, setHasData = () => {}) {
   const { ensgId: ensemblId, efoId } = id;
-  /********     Get JSON Data    ******** */
-  await getGeneDiseaseGtexJSON(
+  /********     Get TCGA JSON Data    ******** */
+  await getGeneDiseaseTcgaJson(
     ensemblId,
     efoId,
     resData => {
@@ -19,8 +19,27 @@ export async function getData(id, setData, setLoading, setHasData = _ => _) {
     error => {
       setHasData(false);
       setLoading(false);
+      console.log("No Data for TCGA Tab: ", error)
     },
-    'summary'
+  );
+}
+
+export async function getGtexData(id, setData, setLoading, setHasData = () => {}) {
+  const { ensgId: ensemblId, efoId } = id;
+  /********     Get GTEx JSON Data    ******** */
+  await getGeneDiseaseGtexJson(
+    ensemblId,
+    efoId,
+    resData => {
+      setData(resData);
+      setHasData(true);
+      setLoading(false);
+    },
+    error => {
+      setHasData(false);
+      setLoading(false);
+      console.log("No Data for GTEx Tab: ", error)
+    },
   );
 }
 
@@ -30,20 +49,26 @@ function Summary({
   displaySettingsForExternal,
   updateDisplaySettingsForExternal,
 }) {
-  const { ensgId: ensemblId, efoId } = id;
-  const [loading, setLoading] = useState(true);
-  const [data, setData] = useState([]);
+  const [gtexLoading, setGtexLoading] = useState(true);
+  const [gtexData, setGtexData] = useState([]);
+
+  const [tcgaLoading, setTcgaLoading] = useState(true);
+  const [tcgaData, setTcgaData] = useState([]);
+
   const [error] = useState(false);
 
   useEffect(
     () => {
       /********     Get JSON Data    ********/
-      if (data.length === 0 && loading === true) {
-        getData(id, setData, setLoading);
+      if (gtexData.length === 0 && gtexLoading === true) {
+        getGtexData(id, setGtexData, setGtexLoading);
+      }
+      if (tcgaData.length === 0 && tcgaLoading === true) {
+        getTcgaData(id, setTcgaData, setTcgaLoading);
       }
       return () => {
         setDisplaySettingForExternal(
-          definition.hasData(data),
+          definition.hasData({ gtexData, tcgaData }),
           definition.id,
           displaySettingsForExternal,
           updateDisplaySettingsForExternal
@@ -51,20 +76,18 @@ function Summary({
       };
     },
     [
-      ensemblId,
-      efoId,
       id,
-      data,
-      setData,
-      setLoading,
       definition,
       displaySettingsForExternal,
       updateDisplaySettingsForExternal,
-      loading,
+      gtexData,
+      gtexLoading,
+      tcgaLoading,
+      tcgaData
     ]
   );
-
-  const request = { loading: loading, data, error: error };
+  const loading = tcgaLoading && gtexLoading;
+  const request = { loading, data: { gtexData, tcgaData }, error: error };
 
   return (
     <SummaryItem

--- a/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/index.js
+++ b/apps/platform/src/sections/evidence/OpenPedCanGeneExpression/index.js
@@ -2,8 +2,8 @@ export const definition = {
   id: 'openPedCanGeneExpression',
   name: 'OpenPedCan Gene Expression',
   shortName: 'GX',
-  hasData: data => {
-    return data ? data.length > 0 : false;
+  hasData: ({ gtexData, tcgaData }) => {
+    return gtexData?.length > 0 || tcgaData?.length > 0 || false;
   },
   color: '#5ca300',
 };

--- a/apps/platform/src/sections/target/OpenPedCanGeneExpression/Body.jsx
+++ b/apps/platform/src/sections/target/OpenPedCanGeneExpression/Body.jsx
@@ -10,8 +10,8 @@ import { Body as OpenPedCanGeneExpression } from '../../common/OpenPedCanGeneExp
 function Body({ definition, id, label: symbol }) {
   const ensemblId = id;
   const downloadFileName = `OpenPedCanGeneExpression-${ensemblId}`;
-  const imageAlt = 'Ssingle-gene all-diseases';
-  const configAPI = `${config.mtpConfig}/front-end/page_target/GeneExpressionGTEx_Config.json`;
+  const imageAlt = 'Single-gene all-diseases';
+  const configAPI = `${config.mtpConfig}/front-end/page_target`;
   return (
     <OpenPedCanGeneExpression
       definition={definition}

--- a/apps/platform/src/sections/target/OpenPedCanGeneExpression/Body.jsx
+++ b/apps/platform/src/sections/target/OpenPedCanGeneExpression/Body.jsx
@@ -1,29 +1,34 @@
 import React from 'react';
-import { getGeneAllCancerPlot } from '../../../utils/externalAPI';
+import { getGeneAllCancerPlot, getGeneAllCancerTcgaPlot } from '../../../utils/externalAPI';
 import config from '../../../config';
 
 import Description from './Description';
 
-import { getData } from './Summary';
+import { getGtexData, getTcgaData } from './Summary';
 import { Body as OpenPedCanGeneExpression } from '../../common/OpenPedCanGeneExpression';
 
 function Body({ definition, id, label: symbol }) {
   const ensemblId = id;
   const downloadFileName = `OpenPedCanGeneExpression-${ensemblId}`;
-  const imageAlt = 'Single-gene all-diseases';
+  const gtexImageAlt = 'Single-gene all-diseases';
+  const tcgaImageAlt = 'Single-gene all-diseases all-TCGA';
+
   const configAPI = `${config.mtpConfig}/front-end/page_target`;
   return (
     <OpenPedCanGeneExpression
       definition={definition}
       id={id}
-      getData={getData}
-      getPlot={getGeneAllCancerPlot}
       label={{ symbol }}
       entity="target"
       Description={Description}
-      fileStem={downloadFileName}
-      imageAlt={imageAlt}
       configAPI={configAPI}
+      fileStem={downloadFileName}
+      getGtexData={getGtexData}
+      getGtexPlot={getGeneAllCancerPlot}
+      gtexImageAlt={gtexImageAlt}
+      getTcgaData={getTcgaData}
+      getTcgaPlot={getGeneAllCancerTcgaPlot}
+      tcgaImageAlt={tcgaImageAlt}
     />
   );
 }

--- a/apps/platform/src/sections/target/OpenPedCanGeneExpression/index.js
+++ b/apps/platform/src/sections/target/OpenPedCanGeneExpression/index.js
@@ -2,8 +2,8 @@ export const definition = {
   id: 'openPedCanGeneExpressionTarget',
   name: 'OpenPedCan Gene Expression',
   shortName: 'GX',
-  hasData: data => {
-    return data ? data.length > 0 : false;
+  hasData: ({ gtexData, tcgaData }) => {
+    return gtexData?.length > 0 || tcgaData?.length > 0 || false;
   },
   color: '#5ca300',
 };

--- a/apps/platform/src/utils/externalAPI.js
+++ b/apps/platform/src/utils/externalAPI.js
@@ -1,137 +1,44 @@
 import axios from 'axios';
 import config from '../config';
 
+const BASE_URL = config.chopRServer;
+
+/*
+ * Define the URLs for the different API endpoints
+ * API DOC: https://openpedcan-api-dev.d3b.io/__docs__/#/
+ */
 const url = {
-  // For Target Page
-  geneAllCancerJSON: '/tpm/gene-all-cancer/json',
-  geneAllCancerPlot: '/tpm/gene-all-cancer/plot',
-  // For Evidence Page
-  geneDiseaseGtexJSON: '/tpm​/gene-disease-gtex​/json',
-  geneDiseaseGtexPlot: '/tpm​/gene-disease-gtex​/plot',
-};
-
-/*
-  Get a single-gene all-diseases TPM summary table          : Evidence Page
-  API DOC https://openpedcan-api-dev.d3b.io/__docs__/#/
- */
-export const getGeneDiseaseGtexJSON = async (
-  ensemblId,
-  efoId,
-  callback,
-  errorHandler = error => {
-    console.log(error);
+  targetPage: {
+    geneAllCancer: {
+      json: '/tpm/gene-all-cancer/json',
+      plot: '/tpm/gene-all-cancer/plot'
+    },
+    geneAllCancerTCGA: {
+      json: '/tpm/gene-all-cancer-tcga/json',
+      plot: '/tpm/gene-all-cancer-tcga/plot'
+    }
   },
-  widget = 'detail'
-) => {
-  const params = {
-    ensemblId: ensemblId,
-    efoId: efoId,
-    includeTumorDesc: 'primaryOnly',
-  };
-  const endpoint = config.chopRServer.concat('/tpm/gene-disease-gtex/json');
-  if (widget === 'detail') {
-    RServerJSONGETFetcher(params, endpoint, callback, errorHandler);
-  } else {
-    RServerJSONGETFetcherForSummary(params, endpoint, callback, errorHandler);
+  evidencePage: {
+    geneDiseaseGtex: {
+      json: '/tpm/gene-disease-gtex/json',
+      plot: '/tpm/gene-disease-gtex/plot'
+    },
+    geneDiseaseTcga: {
+      json: '/tpm/gene-disease-tcga/json',
+      plot: '/tpm/gene-disease-tcga/plot'
+    }
   }
 };
 
 /*
-  Get a single-gene all-diseases TPM boxplot            : Evidence Page
-  API DOC https://openpedcan-api-dev.d3b.io/__docs__/#/
- */
-export const getGeneDiseaseGtexPlot = async (
-  ensemblId,
-  efoId,
-  yAxisScale,
-  callback,
-  errorHandler = error => {
-    console.log(error);
-  }
-) => {
-  const params = {
-    ensemblId: ensemblId,
-    efoId: efoId,
-    yAxisScale: yAxisScale,
-    includeTumorDesc: 'primaryOnly',
-  };
-  let endpoint = config.chopRServer.concat('/tpm/gene-disease-gtex/plot');
-
-  endpoint =
-    endpoint +
-    `?includeTumorDesc=${
-      params.includeTumorDesc
-    }&ensemblId=${ensemblId}&efoId=${efoId}&yAxisScale=${yAxisScale}`;
-  RServerPlotGETFetcher(params, endpoint, callback, errorHandler);
-};
-
-/*
-  Get a single-gene all-diseases TPM summary table          : Target Page
-  API DOC https://openpedcan-api-dev.d3b.io/__docs__/#/
- */
-export const getGeneAllCancerJSON = async (
-  ensemblId,
-  callback,
-  errorHandler = error => {
-    console.log(error);
-  },
-  widget = 'detail'
-) => {
-  const params = {
-    ensemblId: ensemblId,
-    includeTumorDesc: 'primaryOnly',
-  };
-  const endpoint = config.chopRServer.concat(url.geneAllCancerJSON);
-
-  if (widget === 'detail') {
-    RServerJSONGETFetcher(params, endpoint, callback, errorHandler);
-  } else {
-    return RServerJSONGETFetcherForSummary(
-      params,
-      endpoint,
-      callback,
-      errorHandler
-    );
-  }
-};
-
-/*  
-  Get a single-gene all-diseases TPM boxplot              : Target Page
-  API DOC https://openpedcan-api-dev.d3b.io/__docs__/#/
- */
-export const getGeneAllCancerPlot = async (
-  ensemblId,
-  yAxisScale,
-  callback,
-  errorHandler = error => {
-    console.log(error);
-  }
-) => {
-  const params = {
-    ensemblId: ensemblId,
-    yAxisScale: yAxisScale,
-    includeTumorDesc: 'primaryOnly',
-  };
-  let endpoint = config.chopRServer.concat(url.geneAllCancerPlot);
-
-  endpoint =
-    endpoint +
-    `?includeTumorDesc=${
-      params.includeTumorDesc
-    }&ensemblId=${ensemblId}&yAxisScale=${yAxisScale}`;
-  RServerPlotGETFetcher(params, endpoint, callback, errorHandler);
-};
-
-/*
-  JSON Data fetcher for the CHoP R server
+  Function to fetch JSON data from the CHoP R server
+  @params: 
+    - params: Object containing parameters to be passed to the API endpoint
+    - endpoint: String representing the API endpoint to fetch from
+    - callback: Function to handle successful API response
+    - errorHandler: Function to handle API errors
 */
-
-const RServerJSONGETFetcherForSummary = (
-  params,
-  endpoint,
-  callback,
-  errorHandler
-) => {
+const fetchJson = ( params, endpoint, callback, errorHandler ) => {
   axios
     .get(endpoint, { params })
     .then(function(response) {
@@ -143,22 +50,7 @@ const RServerJSONGETFetcherForSummary = (
       ) {
         callback(null);
       } else {
-        errorHandler('err message');
-      }
-    })
-    .catch(function(error) {
-      errorHandler(error);
-    });
-};
-
-const RServerJSONGETFetcher = (params, endpoint, callback, errorHandler) => {
-  axios
-    .get(endpoint, { params })
-    .then(function(response) {
-      if (response.status && response.status === 200) {
-        callback(response.data);
-      } else {
-        errorHandler('err message');
+        errorHandler('Error occurred while fetching data.');
       }
     })
     .catch(function(error) {
@@ -167,19 +59,112 @@ const RServerJSONGETFetcher = (params, endpoint, callback, errorHandler) => {
 };
 
 /*
-  Plot fetcher for the CHoP R server
+  Function to fetch plot data from the CHoP R server
+  @params: 
+    - fullEndpoint: String representing the full API endpoint to fetch from
+    - callback: Function to handle successful API response
+    - errorHandler: Function to handle API errors
 */
-const RServerPlotGETFetcher = (params, endpoint, callback, errorHandler) => {
+const fetchPlot = (fullEndpoint, callback, errorHandler) => {
   axios
-    .get(endpoint, { responseType: 'arraybuffer' })
+    .get(fullEndpoint, { responseType: 'arraybuffer' })
     .then(function(response) {
       if (response.status && response.status === 200) {
         callback(response.data);
       } else {
-        errorHandler('err message');
+        errorHandler('Error occurred while fetching plot.');
       }
     })
     .catch(function(error) {
       errorHandler(error);
     });
+};
+const logError = (error) => console.log(error);
+
+/*
+  Get a single-gene all-diseases all-TCGA TPM summary table          : Target Page (TCGA - JSON)
+ */
+export const getGeneAllCancerTcgaJson = async ( ensemblId, callback, errorHandler = logError ) => {
+  const params = { ensemblId, includeTumorDesc: 'primaryOnly' };
+  const endpoint = BASE_URL.concat(url.targetPage.geneAllCancerTCGA.json);
+
+  fetchJson(params, endpoint, callback, errorHandler);
+};
+
+/*
+  Get a single-gene all-diseases all-TCGA TPM boxplot                : Target Page (TCGA - PLOT)
+*/
+export const getGeneAllCancerTcgaPlot = async ( ensemblId, yAxisScale, callback, errorHandler ) => {
+  const params = { ensemblId, yAxisScale, includeTumorDesc: 'primaryOnly' };
+  const urlParams = new URLSearchParams(params).toString();
+  const endpoint = `${BASE_URL}${url.targetPage.geneAllCancerTCGA.plot}`;
+  const fullEndpoint = `${endpoint}?${urlParams}`;
+
+  fetchPlot(fullEndpoint, callback, errorHandler);
+};
+
+/*
+  Get a single-gene all-diseases TPM summary table                   : Evidence Page (TCGA - JSON)
+ */
+export const getGeneDiseaseTcgaJson = async ( ensemblId, efoId, callback, errorHandler = logError ) => {
+  const params = { ensemblId, efoId, includeTumorDesc: 'primaryOnly' };
+  const endpoint = BASE_URL.concat(url.evidencePage.geneDiseaseTcga.json);
+
+  fetchJson(params, endpoint, callback, errorHandler);
+};
+
+/*  
+  Get a single-gene single-disease all-TCGA TPM boxplot              : Evidence Page (TCGA - PLOT)
+ */
+export const getGeneDiseaseTcgaPlot = async ( ensemblId, efoId, yAxisScale, callback, errorHandler ) =>{
+  const params = { ensemblId, efoId, yAxisScale, includeTumorDesc: 'primaryOnly' };
+  const urlParams = new URLSearchParams(params).toString();
+  const endpoint = `${BASE_URL}${url.evidencePage.geneDiseaseTcga.plot}`;
+  const fullEndpoint = `${endpoint}?${urlParams}`;
+
+  fetchPlot(fullEndpoint, callback, errorHandler);
+};
+
+/*
+  Get a single-gene all-diseases TPM summary table                   : Evidence Page (GTEx - JSON)
+ */
+export const getGeneDiseaseGtexJson = async ( ensemblId, efoId, callback, errorHandler = logError ) => {
+  const params = { ensemblId, efoId, includeTumorDesc: 'primaryOnly' };
+  const endpoint = BASE_URL.concat(url.evidencePage.geneDiseaseGtex.json);
+
+  fetchJson(params, endpoint, callback, errorHandler);
+};
+
+/*
+  Get a single-gene all-diseases TPM boxplot                         : Evidence Page (GTEx - PLOT)
+ */
+export const getGeneDiseaseGtexPlot = async ( ensemblId, efoId, yAxisScale, callback, errorHandler ) => {
+  const params = { ensemblId, efoId, yAxisScale, includeTumorDesc: 'primaryOnly' };
+  const urlParams = new URLSearchParams(params).toString();
+  const endpoint = `${BASE_URL}${url.evidencePage.geneDiseaseGtex.plot}`;
+  const fullEndpoint = `${endpoint}?${urlParams}`;
+
+  fetchPlot(fullEndpoint, callback, errorHandler);
+};
+
+/*
+  Get a single-gene all-diseases TPM summary table                   : Target Page (GTEx - JSON)
+ */
+export const getGeneAllCancerJson = async ( ensemblId, callback, errorHandler = logError ) => {
+  const params = { ensemblId, includeTumorDesc: 'primaryOnly' };
+  const endpoint = `${BASE_URL}${url.targetPage.geneAllCancer.json}`;
+
+  fetchJson(params, endpoint, callback, errorHandler);
+};
+
+/*  
+  Get a single-gene all-diseases TPM boxplot                         : Target Page (GTEx - PLOT)
+ */
+export const getGeneAllCancerPlot = async ( ensemblId, yAxisScale, callback, errorHandler ) => {
+  const params = { ensemblId, yAxisScale, includeTumorDesc: 'primaryOnly' };
+  const urlParams = new URLSearchParams(params).toString();
+  const endpoint = `${BASE_URL}${url.targetPage.geneAllCancer.plot}`;
+  const fullEndpoint = `${endpoint}?${urlParams}`;
+
+  fetchPlot(fullEndpoint, callback, errorHandler);
 };


### PR DESCRIPTION
In this PR:
- OpenPedCan Gene Expression (GX) widget is updated to include two new Tab: `TCGA Linear` and `TCGA Log10`.
- New endpoint are added for TCGA for Target and Evidence page.
- Under Target page:
  - json: [/tpm/gene-all-cancer-tcga/json](https://openpedcan-api-qa.d3b.io/__docs__/#/Bulk%20tissue%20gene%20expression/get_tpm_gene_all_cancer_tcga_json)
  - plot: [/tpm/gene-all-cancer-tcga/plot](https://openpedcan-api-qa.d3b.io/__docs__/#/Bulk%20tissue%20gene%20expression/get_tpm_gene_all_cancer_tcga_plot)
- Under Evidence page:
  - json: [/tpm/gene-disease-tcga/json](https://openpedcan-api-qa.d3b.io/__docs__/#/Bulk%20tissue%20gene%20expression/get_tpm_gene_disease_tcga_json)
  - plot: [/tpm/gene-disease-tcga/plot](https://openpedcan-api-qa.d3b.io/__docs__/#/Bulk%20tissue%20gene%20expression/get_tpm_gene_disease_tcga_plot)


Related Ticket: CCDIMTP-524, CCDIMTP-558, CCDIMTP-559