### PR TITLE
Add downloadBtnLabel prop to DataDownloader

### DIFF
--- a/apps/platform/src/components/Table/DataDownloader.jsx
+++ b/apps/platform/src/components/Table/DataDownloader.jsx
@@ -151,7 +151,7 @@ const styles = makeStyles((theme) => ({
   },
 }));
 
-function DataDownloader({ columns, rows, fileStem, query, variables }) {
+function DataDownloader({ columns, rows, fileStem, query, variables, downloadBtnLabel = 'Download table as' }) {
   const [downloading, setDownloading] = useState(false);
   const [open, setOpen] = useState(false);
   const classes = styles();
@@ -195,7 +195,7 @@ function DataDownloader({ columns, rows, fileStem, query, variables }) {
     <>
       <Grid container alignItems="center" justifyContent="flex-end" spacing={1}>
         <Grid item>
-          <Typography variant="caption">Download table as</Typography>
+          <Typography variant="caption">{downloadBtnLabel}</Typography>
         </Grid>
         <Grid item>
           <Button

--- a/apps/platform/src/components/Table/DataTable.jsx
+++ b/apps/platform/src/components/Table/DataTable.jsx
@@ -29,6 +29,7 @@ function DataTable({
   variables,
   id = "",
   stickyHeader,
+  downloadBtnLabel,
 }) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(initialPageSize);
@@ -106,6 +107,7 @@ function DataTable({
       query={query}
       variables={variables}
       stickyHeader={stickyHeader}
+      downloadBtnLabel={downloadBtnLabel}
     />
   );
 }

--- a/apps/platform/src/components/Table/Table.jsx
+++ b/apps/platform/src/components/Table/Table.jsx
@@ -52,6 +52,7 @@ const Table = ({
   variables,
   stickyHeader,
   id,
+  downloadBtnLabel,
 }) => {
   const emptyRows = pageSize - rows.length;
   const [selectedRow, setSelectedRow] = useState(0);
@@ -103,6 +104,7 @@ const Table = ({
               fileStem={dataDownloaderFileStem}
               query={query}
               variables={variables}
+              downloadBtnLabel={downloadBtnLabel}
             />
           </Grid>
         )}


### PR DESCRIPTION
Update the `DataDownloader` component to accept new prop called `downloadBtnLabel` to replace the hardcoded text of "Download table as".