### PR TITLE
CCDIMTP-568 (Add HGVSg ID column)

### DIFF
--- a/apps/platform/src/pages/APIPage/SomaticAlterationsQuery.gql
+++ b/apps/platform/src/pages/APIPage/SomaticAlterationsQuery.gql
@@ -177,6 +177,7 @@ query SomaticAlterationsQuery {
         totalRelapseTumorsMutatedOverRelapseTumorsInDataset
         vepImpact
         variantIdHg38
+        variantHgvsId
         variantClassification
         variantType
         dbSNPId

--- a/apps/platform/src/sections/evidence/OpenPedCanSomaticAlterations/SomaticAlterationsQuery.gql
+++ b/apps/platform/src/sections/evidence/OpenPedCanSomaticAlterations/SomaticAlterationsQuery.gql
@@ -181,6 +181,7 @@ query SomaticAlterationsQuery(
         totalRelapseTumorsMutatedOverRelapseTumorsInDataset
         vepImpact
         variantIdHg38
+        variantHgvsId
         variantClassification
         variantType
         dbSNPId

--- a/apps/platform/src/sections/target/OpenPedCanSomaticAlterations/SomaticAlterationsQuery.gql
+++ b/apps/platform/src/sections/target/OpenPedCanSomaticAlterations/SomaticAlterationsQuery.gql
@@ -163,6 +163,7 @@ query SomaticAlterationsQuery($ensemblId: String!, $size: Int = 20) {
         totalRelapseTumorsMutatedOverRelapseTumorsInDataset
         vepImpact
         variantIdHg38
+        variantHgvsId
         variantClassification
         variantType
         dbSNPId


### PR DESCRIPTION
- Add new column called "HGVSg ID" under `OpenPedCan Somatic Alterations(SA)` - `SNV By Variant` table on `target` and `evidence` pages
- SA query update is also reflected under `GraphQL API`page
- Table config PR: https://github.com/CBIIT/ccdi-mtp-config/pull/38