### PR TITLE
Update datasourceid for EM widget

### DIFF
--- a/apps/platform/src/sections/common/EpigeneticModification/Body.jsx
+++ b/apps/platform/src/sections/common/EpigeneticModification/Body.jsx
@@ -23,7 +23,7 @@ function Body({
   configAPI,
 }) {
   const request = useQuery(BODY_QUERY, {
-    variables: { ...variables, size: 9999 },
+    variables: { ...variables, size: 8300 }, // 9999;
   });
   // Tabs under Epigenetic Modification widget
   const emTabs = ['methylationByGene', 'methylationByIsoform']

--- a/apps/platform/src/sections/evidence/EpigeneticModification/EpigeneticModificationQuery.gql
+++ b/apps/platform/src/sections/evidence/EpigeneticModification/EpigeneticModificationQuery.gql
@@ -40,7 +40,7 @@ query EpigeneticModificationQuery(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       size: $size
-      datasourceIds: ["chop_transcript_level_methylation"]
+      datasourceIds: ["chop_isoform_level_methylation"]
     ) {
       count
       rows {

--- a/apps/platform/src/sections/evidence/EpigeneticModification/EpigeneticModificationSummary.gql
+++ b/apps/platform/src/sections/evidence/EpigeneticModification/EpigeneticModificationSummary.gql
@@ -12,7 +12,7 @@ fragment evidenceEpigeneticModificationSummary on Disease {
     ensemblIds: [$ensgId]
     enableIndirect: true
     size: 0
-    datasourceIds: ["chop_transcript_level_methylation"]
+    datasourceIds: ["chop_isoform_level_methylation"]
   ) {
     count
   }

--- a/apps/platform/src/sections/target/EpigeneticModification/EpigeneticModificationQuery.gql
+++ b/apps/platform/src/sections/target/EpigeneticModification/EpigeneticModificationQuery.gql
@@ -34,7 +34,7 @@ query EpigeneticModificationQuery($ensemblId: String!, $size: Int = 20) {
     evidences(
       efoIds: []
       size: $size
-      datasourceIds: ["chop_transcript_level_methylation"]
+      datasourceIds: ["chop_isoform_level_methylation"]
     ) {
       count
       rows {

--- a/apps/platform/src/sections/target/EpigeneticModification/EpigeneticModificationSummary.gql
+++ b/apps/platform/src/sections/target/EpigeneticModification/EpigeneticModificationSummary.gql
@@ -10,7 +10,7 @@ fragment targetEpigeneticModificationSummary on Target {
   methylationByIsoform: evidences(
     efoIds: []
     size: 0
-    datasourceIds: ["chop_transcript_level_methylation"]
+    datasourceIds: ["chop_isoform_level_methylation"]
   ) {
     count
   }


### PR DESCRIPTION
- Update `datasourceid` for `Epigenetic Modification(EM)` widget. Specifically for the "Methylation By Isoform" table.
- Decrease the maximum number of rows to query at once to avoid errors